### PR TITLE
Finished class 1208 (Slide Navigation)

### DIFF
--- a/annotations.txt
+++ b/annotations.txt
@@ -1,23 +1,14 @@
 Projeto Slide do curso ORIGAMID ES6+ | Módulo 12 (Slide)
 
-Aula 1207 (Slide Resize)
+Aula 1208 (Slide Navigation)
 
-CSS:
-Dica para "forçar" uma borda arredondada num determinado elemento:
-`
-<css-selector> {
-  border-radius: 4px;
-  overflow: hidden;
-}
-`
+No momento, a classe 'Slide' está com suas funcionalidades
+prontas. A partir de agora, serão adicionados alguns
+complementos com respeito ao site, como os botões de navegação.
 
-#!important:
-O evento 'resize' é acionado em dispositivos mobile quando o usuário
-alterna a orientação da tela, por isso é importante desenvolver
-uma função que lida com esse evento, além de aplicar a função
-do tipo 'debounce' à sua callback, pois o evento 'resize' é disparado
-centenas de vezes e consequentemente sua callback também.
+Prestar atenção nos métodos:
+'slideConfig' e 'changeSlide', pois a aplicação
+precisa desses métodos para ter um comportamento adequado.
 
-Como boa prática, a função de debounce é aplicada no momento que se faz
-o 'binding' da callback do evento.
- 
+Assim, será criada uma classe 'SlideNav' e essa ESTENDERÁ
+a classe 'Slide'.

--- a/index.html
+++ b/index.html
@@ -19,6 +19,10 @@
       <li><img src="img/foto6.jpg" alt="a lion picture"></li>
     </ul>
   </div>
+  <div class="arrow-nav">
+    <button class="prev">Prev</button>
+    <button class="next">Next</button>
+  </div>
   <script type="module" src="js/script.js"></script>
 </body>
 

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,5 @@
-import Slide from "./slide.js";
+import { SlideNav } from "./slide.js";
 
-const slide = new Slide('.slide', '.slide-wrapper');
+const slide = new SlideNav('.slide', '.slide-wrapper');
 slide.init();
+slide.addArrow('.prev', '.next');

--- a/js/slide.js
+++ b/js/slide.js
@@ -1,6 +1,6 @@
 import debounce from './debounce.js';
 
-export default class Slide {
+export class Slide {
   constructor(slide, wrapper) {
     this.slide = document.querySelector(slide);
     this.wrapper = document.querySelector(wrapper);
@@ -23,9 +23,9 @@ export default class Slide {
   }
 
   onStart(event) {
+    event.preventDefault();
     let moveType;
     if (event.type === 'mousedown') {
-      event.preventDefault();
       this.dist.startX = event.clientX;
       moveType = 'mousemove';
     } else {
@@ -124,6 +124,10 @@ export default class Slide {
     this.onStart = this.onStart.bind(this);
     this.onMove = this.onMove.bind(this);
     this.onEnd = this.onEnd.bind(this);
+
+    this.activePrevSlide = this.activePrevSlide.bind(this);
+    this.activeNextSlide = this.activeNextSlide.bind(this);
+
     this.onResize = debounce(this.onResize.bind(this), 200);
   }
 
@@ -135,5 +139,18 @@ export default class Slide {
     this.changeSlide(0);
     this.addResizeEvent();
     return this;
+  }
+}
+
+export class SlideNav extends Slide {
+  addArrow(prev, next) {
+    this.prevElement = document.querySelector(prev);
+    this.nextElement = document.querySelector(next);
+    this.addArrowEvent();
+  }
+
+  addArrowEvent() {
+    this.prevElement.addEventListener('click', this.activePrevSlide);
+    this.nextElement.addEventListener('click', this.activeNextSlide);
   }
 }


### PR DESCRIPTION
created class 'SlideNav' and extends the class 'Slide' | created 'addArrow', 'addArrowEvent' to select HTMLElements to go to prev and next slide through UI and adds 'click' event on these elements | moved 'event.preventDefault' method at top of 'onStart' method to prevents 'double click' effect by 'touchstart' event | At 'script.js', it was changed to way to import the 'Slide' class to import the 'SlideNav' class because it extends the 'Slide' class.